### PR TITLE
Minor tweaks and fixes

### DIFF
--- a/server/out/weidu.completion.yml
+++ b/server/out/weidu.completion.yml
@@ -9433,6 +9433,18 @@ tp2-vars:
       doc: Set by `COPY_*` family of functions. If `COPY fromFile` is `mymod/cre/bigboss.cre`, then `SOURCE_RES` is `bigboss`.
     - name: SOURCE_EXT
       doc: Set by `COPY_*` family of functions. If `COPY fromFile` is `mymod/cre/bigboss.cre`, then `SOURCE_EXT` is `cre`.
+    - name: SOURCE_SIZE
+      doc: Set by `COPY_*` family of functions. It is set to the size (in bytes) of the source file.
+    - name: DEST_FILE
+      doc: Set by `COPY_*` family of functions. Like `SOURCE_FILE`, but based on `toFile`.
+    - name: DEST_DIRECTORY
+      doc: Set by `COPY_*` family of functions. Like `SOURCE_DIRECTORY`, but based on `toFile`.
+    - name: DEST_FILESPEC
+      doc: Set by `COPY_*` family of functions. Like `SOURCE_FILESPEC`, but based on `toFile`.
+    - name: DEST_RES
+      doc: Set by `COPY_*` family of functions. Like `SOURCE_RES`, but based on `toFile`.
+    - name: DEST_EXT
+      doc: Set by `COPY_*` family of functions. Like `SOURCE_EXT`, but based on `toFile`.
 
 tp2-file:
   type: 14 # keyword

--- a/syntaxes/weidu.baf.tmLanguage.yml
+++ b/syntaxes/weidu.baf.tmLanguage.yml
@@ -2043,6 +2043,7 @@ repository:
   spell-ids-iwdee:
     name: constant.other.baf.weidu
     patterns:
+      - match: \b(CLERIC_CURSE)\b
       - match: \b(CLERIC_CAUSE_LIGHT_WOUNDS)\b
       - match: \b(CLERIC_SUNSCORCH)\b
       - match: \b(CLERIC_PROTECT_FROM_GOOD)\b
@@ -2064,7 +2065,7 @@ repository:
       - match: \b(CLERIC_SUMMON_LIZARDMEN)\b
       - match: \b(CLERIC_SUMMON_TROLLS)\b
       - match: \b(CLERIC_CAUSE_MEDIUM_WOUNDS)\b
-      - match: \b(CLERIC_FAVOR_OR_ILMATER)\b
+      - match: \b(CLERIC_FAVOR_OF_ILMATER)\b
       - match: \b(CLERIC_GIANT_INSECT)\b
       - match: \b(CLERIC_PRODUCE_FIRE)\b
       - match: \b(CLERIC_STATIC_CHARGE)\b

--- a/syntaxes/weidu.tmLanguage.yml
+++ b/syntaxes/weidu.tmLanguage.yml
@@ -4750,7 +4750,7 @@ repository:
     patterns:
       - include: '#weidu-vars'
       - include: '#ielib-constants'
-      - match: (%)((\w*)(%[#\-\w]+%)(\w*))(%)
+      - match: (%)((\w*)(%[#!\-\w]+%)(\w*))(%)
         captures:
           '1':
             name: keyword.control.double-eval.weidu
@@ -4760,7 +4760,7 @@ repository:
             name: keyword.control.double-eval.weidu
           '6':
             name: keyword.control.double-eval.weidu
-      - match: (%[#\-\w]+%)
+      - match: (%[#!\-\w]+%)
 
   vars:
     patterns:


### PR DESCRIPTION
- Fixed typo in `CLERIC_FAVOR_OR_ILMATER`.
- Added some missing `tp2-vars` to autocompletion.
- Added one missing spell to `spell-ids-iwdee`.
- Allow more char types in weidu var names.
  - This is mainly to capture Argent77 var names (`A7!`).