### PR TITLE
Added missing "GTIMES.IDS" and "LOCAL_SET/LOCAL_TEXT_SPRINT/LOCAL_SPRINT"

### DIFF
--- a/server/out/weidu.completion.yml
+++ b/server/out/weidu.completion.yml
@@ -10047,6 +10047,12 @@ tp2-action:
       detail: OUTER_SET variable = value
       doc: |-
         Update variable so that it is equal to value.
+    - name: LOCAL_SET
+      detail: LOCAL_SET variable = value
+      doc: |-
+        Update variable so that it is equal to value. Only usable in ACTION and PATCH macros.
+
+        Basically, at the beginning of the macro declaration, you may use `LOCAL_SET variable = value` to declare a variable as local, and assign it a new value. Use this for all variables that don't need to be changed by the macro. After computing the macro, these variables are set to the value they had before the macro was processed.
     - name: OUTER_SNPRINT
       detail: OUTER_SNPRINT value variable stringWithVars
       doc: |-
@@ -10055,10 +10061,20 @@ tp2-action:
       detail: OUTER_SPRINT variable stringWithVars
       doc: |-
         Like OUTER_TEXT_SPRINT, but stringWithVars can be an @reference, and will break --traify. Use OUTER_TEXT_SPRINT instead.
+    - name: LOCAL_SPRINT
+      detail: LOCAL_SPRINT variable stringWithVars
+      doc: |-
+        Like LOCAL_TEXT_SPRINT, but stringWithVars can be an @reference, and will break --traify. Use LOCAL_TEXT_SPRINT instead.
     - name: OUTER_TEXT_SPRINT
       detail: OUTER_TEXT_SPRINT variable stringWithVars
       doc: |-
         Any WeiDU variables (enclosed in %s) inside stringWithVars are replaced by their values and the resulting string (constructed at mod-installation time!) is assigned to the variable variable.
+    - name: LOCAL_TEXT_SPRINT
+      detail: LOCAL_TEXT_SPRINT variable stringWithVars
+      doc: |-
+        Any WeiDU variables (enclosed in %s) inside stringWithVars are replaced by their values and the resulting string (constructed at mod-installation time!) is assigned to the variable variable. Only usable in ACTION and PATCH macros.
+
+        Basically, at the beginning of the macro declaration, you may use `LOCAL_TEXT_SPRINT variable stringWithVars` to declare a variable as local, and assign it a new value. Use this for all variables that don't need to be changed by the macro. After computing the macro, these variables are set to the value they had before the macro was processed.
     - name: OUTER_WHILE
       detail: OUTER_WHILE value BEGIN TP2 Action list END
       doc: |-

--- a/syntaxes/weidu.baf.tmLanguage.yml
+++ b/syntaxes/weidu.baf.tmLanguage.yml
@@ -137,6 +137,7 @@ repository:
       - include: '#seq-ids'
       - include: '#time-ids'
       - include: '#timeoday-ids'
+      - include: '#gtimes-ids'
       - include: '#weather-ids'
       - include: '#xequip-ids'
       - include: '#statmod-ids'
@@ -2753,6 +2754,108 @@ repository:
       - match: \b(DUSK)\b
       - match: \b(NIGHT)\b
       - match: \b(MORNING)\b
+
+  gtimes-ids:
+    name: constant.other.baf.weidu
+    patterns:
+      - match: \b(ONE_MINUTE)\b
+      - match: \b(ONE_ROUND)\b
+      - match: \b(TWO_MINUTES)\b
+      - match: \b(TWO_ROUNDS)\b
+      - match: \b(THREE_MINUTES)\b
+      - match: \b(THREE_ROUNDS)\b
+      - match: \b(FOUR_MINUTES)\b
+      - match: \b(FOUR_ROUNDS)\b
+      - match: \b(FIVE_MINUTES)\b
+      - match: \b(FIVE_ROUNDS)\b
+      - match: \b(SIX_MINUTES)\b
+      - match: \b(SEVEN_MINUTES)\b
+      - match: \b(SIX_ROUNDS)\b
+      - match: \b(EIGHT_MINUTES)\b
+      - match: \b(SEVEN_ROUNDS)\b
+      - match: \b(NINE_MINUTES)\b
+      - match: \b(EIGHT_ROUNDS)\b
+      - match: \b(TEN_MINUTES)\b
+      - match: \b(NINE_ROUNDS)\b
+      - match: \b(ELEVEN_MINUTES)\b
+      - match: \b(TEN_ROUNDS)\b
+      - match: \b(ONE_TURN)\b
+      - match: \b(TWELVE_MINUTES)\b
+      - match: \b(THIRTEEN_MINUTES)\b
+      - match: \b(FOURTEEN_MINUTES)\b
+      - match: \b(FIFTEEN_MINUTES)\b
+      - match: \b(SIXTEEN_MINUTES)\b
+      - match: \b(SEVENTEEN_MINUTES)\b
+      - match: \b(EIGHTEEN_MINUTES)\b
+      - match: \b(NINETEEN_MINUTES)\b
+      - match: \b(TWENTY_MINUTES)\b
+      - match: \b(TWO_TURNS)\b
+      - match: \b(THIRTY_MINUTES)\b
+      - match: \b(THREE_TURNS)\b
+      - match: \b(FORTY_MINUTES)\b
+      - match: \b(FOUR_TURNS)\b
+      - match: \b(FIFTY_MINUTES)\b
+      - match: \b(ONE_HOUR)\b
+      - match: \b(FIVE_TURNS)\b
+      - match: \b(SIX_TURNS)\b
+      - match: \b(SEVEN_TURNS)\b
+      - match: \b(EIGHT_TURNS)\b
+      - match: \b(NINE_TURNS)\b
+      - match: \b(TWO_HOURS)\b
+      - match: \b(TEN_TURNS)\b
+      - match: \b(ELEVEN_TURNS)\b
+      - match: \b(TWELVE_TURNS)\b
+      - match: \b(THIRTEEN_TURNS)\b
+      - match: \b(FOURTEEN_TURNS)\b
+      - match: \b(THREE_HOURS)\b
+      - match: \b(FIFTEEN_TURNS)\b
+      - match: \b(FOUR_HOURS)\b
+      - match: \b(FIVE_HOURS)\b
+      - match: \b(SIX_HOURS)\b
+      - match: \b(SEVEN_HOURS)\b
+      - match: \b(EIGHT_HOURS)\b
+      - match: \b(NINE_HOURS)\b
+      - match: \b(TEN_HOURS)\b
+      - match: \b(ELEVEN_HOURS)\b
+      - match: \b(TWELVE_HOURS)\b
+      - match: \b(THIRTEEN_HOURS)\b
+      - match: \b(FOURTEEN_HOURS)\b
+      - match: \b(FIFTEEN_HOURS)\b
+      - match: \b(SIXTEEN_HOURS)\b
+      - match: \b(SEVENTEEN_HOURS)\b
+      - match: \b(EIGHTEEN_HOURS)\b
+      - match: \b(NINETEEN_HOURS)\b
+      - match: \b(TWENTY_HOURS)\b
+      - match: \b(TWENTYONE_HOURS)\b
+      - match: \b(TWENTYTWO_HOURS)\b
+      - match: \b(TWENTYTHREE_HOURS)\b
+      - match: \b(ONE_DAY)\b
+      - match: \b(TWO_DAYS)\b
+      - match: \b(THREE_DAYS)\b
+      - match: \b(FOUR_DAYS)\b
+      - match: \b(FIVE_DAYS)\b
+      - match: \b(SIX_DAYS)\b
+      - match: \b(SEVEN_DAYS)\b
+      - match: \b(ONE_WEEK)\b
+      - match: \b(EIGHT_DAYS)\b
+      - match: \b(NINE_DAYS)\b
+      - match: \b(TEN_DAYS)\b
+      - match: \b(ELEVEN_DAYS)\b
+      - match: \b(TWELVE_DAYS)\b
+      - match: \b(THIRTEEN_DAYS)\b
+      - match: \b(FOURTEEN_DAYS)\b
+      - match: \b(FIFTEEN_DAYS)\b
+      - match: \b(SIXTEEN_DAYS)\b
+      - match: \b(SEVENTEEN_DAYS)\b
+      - match: \b(EIGHTEEN_DAYS)\b
+      - match: \b(NINETEEN_DAYS)\b
+      - match: \b(TWENTY_DAYS)\b
+      - match: \b(TWENTYTWO_DAYS)\b
+      - match: \b(TWENTYFIVE_DAYS)\b
+      - match: \b(THIRTY_DAYS)\b
+      - match: \b(ONE_MONTH)\b
+      - match: \b(FORTY_DAYS)\b
+      - match: \b(FIFTY_DAYS)\b
 
   weather-ids:
     name: constant.other.baf.weidu

--- a/syntaxes/weidu.tmLanguage.yml
+++ b/syntaxes/weidu.tmLanguage.yml
@@ -4364,6 +4364,7 @@ repository:
       - match: \b(SPRINT)\b
       - match: \b(SNPRINT)\b
       - match: \b(SPRINTF)\b
+      - match: \b(LOCAL_TEXT_SPRINT)\b
       - match: \b(LOCAL_SPRINT)\b
       - match: \b(LOCAL_SET)\b
       - match: \b(SOURCE_BIFF)\b


### PR DESCRIPTION
- Added missing `GTIMES.IDS` identifiers (`*.baf`, `*.ssl`).
- Added some details (description) for `LOCAL_SET`, `LOCAL_TEXT_SPRINT` and `LOCAL_SPRINT`.