### PR TITLE
Negative TRA references

### DIFF
--- a/syntaxes/weidu-tra.tmLanguage.yml
+++ b/syntaxes/weidu-tra.tmLanguage.yml
@@ -23,7 +23,7 @@ repository:
             name: constant.language.weidu-tra
           "3":
             name: keyword.control.weidu-tra
-        match: (@)(\d+)\s*(=)
+        match: (@)-?(\d+)\s*(=)
   sounds:
     patterns:
       - captures:


### PR DESCRIPTION
In `*.tra` files `@integer` can also be `@-integer` (f.i. `@-110`).