### PR TITLE
Fix handling when workspaceRoot is undefined

### DIFF
--- a/server/src/common.ts
+++ b/server/src/common.ts
@@ -115,6 +115,10 @@ export function sendParseResult(parseResult: ParseResult, mainUri: string, tmpUr
 /** Check if 1st dir contains the 2nd
  */
 export function isSubpath(outerPath: string, innerPath: string) {
+    // hack: don't crash when workspaceRoot is undefined
+    if (outerPath === undefined) {
+        return false;
+    }
     const innerReal = fs.realpathSync(innerPath);
     const outerReal = fs.realpathSync(outerPath);
     if (innerReal.startsWith(outerReal)) {

--- a/server/src/galactus.ts
+++ b/server/src/galactus.ts
@@ -277,9 +277,11 @@ export class Galactus {
             isTraRef(symbol, langId)
         ) {
             const filePath = uriToPath(uri);
-            const relPath = getRelPath(this.workspaceRoot, filePath);
-            const result = this.translation.hover(symbol, text, relPath, langId);
-            return result;
+            if (isSubpath(this.workspaceRoot, filePath)) {
+                const relPath = getRelPath(this.workspaceRoot, filePath);
+                const result = this.translation.hover(symbol, text, relPath, langId);
+                return result;
+            }
         }
 
         // no translation, now check real languages

--- a/server/src/language.ts
+++ b/server/src/language.ts
@@ -97,17 +97,18 @@ export class Language implements Language {
     }
 
     private async loadHeaders(staticHover: hover.HoverMap = new Map()) {
-        if (this.workspaceRoot !== undefined) {
-            if (this.id == "fallout-ssl") {
-                const res = await fallout.loadHeaders(this.workspaceRoot, false, staticHover);
-                return res;
-            }
-            if (this.id == "weidu-tp2") {
-                const res = weidu.loadHeaders(this.workspaceRoot);
-                return res;
-            }
-            conlog(`Unknown language id ${this.id}, can't load headers.`);
+        if (this.workspaceRoot === undefined) {
+            return;
         }
+        if (this.id == "fallout-ssl") {
+            const res = await fallout.loadHeaders(this.workspaceRoot, false, staticHover);
+            return res;
+        }
+        if (this.id == "weidu-tp2") {
+            const res = weidu.loadHeaders(this.workspaceRoot);
+            return res;
+        }
+        conlog(`Unknown language id ${this.id}, can't load headers.`);
     }
 
     private async loadExternalHeaders(staticHover: hover.HoverMap = new Map()) {

--- a/server/src/language.ts
+++ b/server/src/language.ts
@@ -97,15 +97,17 @@ export class Language implements Language {
     }
 
     private async loadHeaders(staticHover: hover.HoverMap = new Map()) {
-        if (this.id == "fallout-ssl") {
-            const res = await fallout.loadHeaders(this.workspaceRoot, false, staticHover);
-            return res;
+        if (this.workspaceRoot !== undefined) {
+            if (this.id == "fallout-ssl") {
+                const res = await fallout.loadHeaders(this.workspaceRoot, false, staticHover);
+                return res;
+            }
+            if (this.id == "weidu-tp2") {
+                const res = weidu.loadHeaders(this.workspaceRoot);
+                return res;
+            }
+            conlog(`Unknown language id ${this.id}, can't load headers.`);
         }
-        if (this.id == "weidu-tp2") {
-            const res = weidu.loadHeaders(this.workspaceRoot);
-            return res;
-        }
-        conlog(`Unknown language id ${this.id}, can't load headers.`);
     }
 
     private async loadExternalHeaders(staticHover: hover.HoverMap = new Map()) {

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -57,19 +57,21 @@ const defaultProjectSettings: ProjectSettings = {
 /** get project settings from .bgforge.yml */
 export function project(dir: string) {
     const settings = defaultProjectSettings;
-    try {
-        const file = fs.readFileSync(path.join(dir, ".bgforge.yml"), "utf8");
-        const yml_settings = yaml.parse(file).mls;
-        if (yml_settings.translation) {
-            if (yml_settings.translation.directory) {
-                settings.translation.directory = yml_settings.translation.directory;
+    if (dir !== undefined) {
+        try {
+            const file = fs.readFileSync(path.join(dir, ".bgforge.yml"), "utf8");
+            const yml_settings = yaml.parse(file).mls;
+            if (yml_settings.translation) {
+                if (yml_settings.translation.directory) {
+                    settings.translation.directory = yml_settings.translation.directory;
+                }
+                if (yml_settings.translation.auto_tra) {
+                    settings.translation.auto_tra = yml_settings.translation.auto_tra;
+                }
             }
-            if (yml_settings.translation.auto_tra) {
-                settings.translation.auto_tra = yml_settings.translation.auto_tra;
-            }
+        } catch (e) {
+            conlog(e);
         }
-    } catch (e) {
-        conlog(e);
     }
     return settings;
 }

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -57,21 +57,22 @@ const defaultProjectSettings: ProjectSettings = {
 /** get project settings from .bgforge.yml */
 export function project(dir: string) {
     const settings = defaultProjectSettings;
-    if (dir !== undefined) {
-        try {
-            const file = fs.readFileSync(path.join(dir, ".bgforge.yml"), "utf8");
-            const yml_settings = yaml.parse(file).mls;
-            if (yml_settings.translation) {
-                if (yml_settings.translation.directory) {
-                    settings.translation.directory = yml_settings.translation.directory;
-                }
-                if (yml_settings.translation.auto_tra) {
-                    settings.translation.auto_tra = yml_settings.translation.auto_tra;
-                }
+    if (dir === undefined) {
+        return settings;
+    }
+    try {
+        const file = fs.readFileSync(path.join(dir, ".bgforge.yml"), "utf8");
+        const yml_settings = yaml.parse(file).mls;
+        if (yml_settings.translation) {
+            if (yml_settings.translation.directory) {
+                settings.translation.directory = yml_settings.translation.directory;
             }
-        } catch (e) {
-            conlog(e);
+            if (yml_settings.translation.auto_tra) {
+                settings.translation.auto_tra = yml_settings.translation.auto_tra;
+            }
         }
+    } catch (e) {
+        conlog(e);
     }
     return settings;
 }


### PR DESCRIPTION
`workspaceRoot` is `undefined` when a file is opened without first opening a folder. I've attempted to fix all instances where `workspaceRoot === undefined` caused a crash, undefined behavior, or an error to be logged.