### PR TITLE
Misc fixes and tweaks

### DIFF
--- a/server/data/weidu-tp2-base.yml
+++ b/server/data/weidu-tp2-base.yml
@@ -350,9 +350,10 @@ tp2-action:
         newMUSFile is copied to the music directory and added to songlist.2da under the name internalMusicName. The variable %internalMusicName% is set to the number of this new entry in songlist.2da. If newMUSFile already exists, the variable %internalMusicName% is set to the existing entry in songlist.2da and all other operations are skipped. Variables are evaluated. Some versions of the Infinity Engine cannot handle more than 100 entries in songlist.2da. ADD_MUSIC will fail under those circumstances unless the appropriate versions of ToB Hacks or ToBEx are installed or the game is GemRB or BGEE.
 
     - name: ADD_PROJECTILE
-      detail: ADD_PROJECTILE modpath/PROName.PRO
+      detail: ADD_PROJECTILE modpath/PROName.PRO idsName
       doc: |-
         Appends an entry for PROName to PROJECTL.IDS and assigns it the next available ProRef number. Then copies the file modpath/PROName.PRO to the override folder. The new ProRef number can be accessed through the variable %PROName% and used to updated the Projectile type field of an ITM or SPL file's Item Ability or Spell Ability sub-structures.
+        If `idsName` is specified, then it will give the projectile the name `idsName` in `MISSILE.IDS`.
 
     - name: ADD_SCHOOL
       detail: ADD_SCHOOL schoolName removalString
@@ -2794,6 +2795,9 @@ tp2-value:
     - name: "%WEIDU_ARCH%"
       doc: |-
         The special variable WEIDU_ARCH is set to either "x86", "amd64" or "mac" at WeiDU startup and can be used to determine the architecture of the WeiDU binary.
+    - name: "%WEIDU_EXECUTABLE%"
+      doc: |-
+        The special variable WEIDU_EXECUTABLE contains the full path of the current WeiDU binary.
     - name: "%WEIDU_OS%"
       doc: |-
         The special variable WEIDU_OS is set to either "win32" or "osx" or "unix" at WeiDU startup and can be used to determine the operating system for which the WeiDU binary was compiled.

--- a/server/data/weidu-tp2-base.yml
+++ b/server/data/weidu-tp2-base.yml
@@ -350,7 +350,7 @@ tp2-action:
         newMUSFile is copied to the music directory and added to songlist.2da under the name internalMusicName. The variable %internalMusicName% is set to the number of this new entry in songlist.2da. If newMUSFile already exists, the variable %internalMusicName% is set to the existing entry in songlist.2da and all other operations are skipped. Variables are evaluated. Some versions of the Infinity Engine cannot handle more than 100 entries in songlist.2da. ADD_MUSIC will fail under those circumstances unless the appropriate versions of ToB Hacks or ToBEx are installed or the game is GemRB or BGEE.
 
     - name: ADD_PROJECTILE
-      detail: ADD_PROJECTILE modpath/PROName.PRO idsName
+      detail: ADD_PROJECTILE modpath/PROName.PRO [idsName]
       doc: |-
         Appends an entry for PROName to PROJECTL.IDS and assigns it the next available ProRef number. Then copies the file modpath/PROName.PRO to the override folder. The new ProRef number can be accessed through the variable %PROName% and used to updated the Projectile type field of an ITM or SPL file's Item Ability or Spell Ability sub-structures.
         If `idsName` is specified, then it will give the projectile the name `idsName` in `MISSILE.IDS`.

--- a/server/data/weidu-tp2-ielib.yml
+++ b/server/data/weidu-tp2-ielib.yml
@@ -3803,6 +3803,9 @@ ielib-resref:
     - name: WIZARD_REMOVE_MAGIC
       detail: resref WIZARD_REMOVE_MAGIC = "SPWI302"
       doc: IElib define
+    - name: WIZARD_DISPEL_MAGIC
+      detail: resref WIZARD_DISPEL_MAGIC = "SPWI302"
+      doc: IElib define
     - name: WIZARD_RESIST_FEAR
       detail: resref WIZARD_RESIST_FEAR = "SPWI210"
       doc: IElib define

--- a/server/data/weidu-tp2-ielib.yml
+++ b/server/data/weidu-tp2-ielib.yml
@@ -3803,9 +3803,6 @@ ielib-resref:
     - name: WIZARD_REMOVE_MAGIC
       detail: resref WIZARD_REMOVE_MAGIC = "SPWI302"
       doc: IElib define
-    - name: WIZARD_DISPEL_MAGIC
-      detail: resref WIZARD_DISPEL_MAGIC = "SPWI302"
-      doc: IElib define
     - name: WIZARD_RESIST_FEAR
       detail: resref WIZARD_RESIST_FEAR = "SPWI210"
       doc: IElib define

--- a/syntaxes/weidu-tp2.tmLanguage.yml
+++ b/syntaxes/weidu-tp2.tmLanguage.yml
@@ -1235,6 +1235,7 @@ repository:
       - match: (%SCROLL_WIZARD_TIME_STOP%)
       - match: (%SCROLL_WIZARD_TROLLISH_FORTITUDE%)
       - match: (%SCROLL_WIZARD_TRUE_DISPEL_MAGIC%)
+      - match: (%SCROLL_WIZARD_DISPEL_MAGIC%)
       - match: (%SCROLL_WIZARD_TRUE_SIGHT%)
       - match: (%SCROLL_WIZARD_VAMPIRIC_TOUCH%)
       - match: (%SCROLL_WIZARD_VITRIOLIC_SPHERE%)
@@ -1642,6 +1643,7 @@ repository:
       - match: (%WIZARD_TENSERS_TRANSFORMATION%)
       - match: (%WIZARD_TIME_STOP%)
       - match: (%WIZARD_TRUE_DISPEL_MAGIC%)
+      - match: (%WIZARD_DISPEL_MAGIC%)
       - match: (%WIZARD_TRUE_SIGHT%)
       - match: (%WIZARD_VAMPIRIC_TOUCH%)
       - match: (%WIZARD_VOCALIZE%)
@@ -2484,6 +2486,7 @@ repository:
       - match: \b(SCROLL_WIZARD_TIME_STOP)\b
       - match: \b(SCROLL_WIZARD_TROLLISH_FORTITUDE)\b
       - match: \b(SCROLL_WIZARD_TRUE_DISPEL_MAGIC)\b
+      - match: \b(SCROLL_WIZARD_DISPEL_MAGIC)\b
       - match: \b(SCROLL_WIZARD_TRUE_SIGHT)\b
       - match: \b(SCROLL_WIZARD_VAMPIRIC_TOUCH)\b
       - match: \b(SCROLL_WIZARD_VITRIOLIC_SPHERE)\b
@@ -2891,6 +2894,7 @@ repository:
       - match: \b(WIZARD_TENSERS_TRANSFORMATION)\b
       - match: \b(WIZARD_TIME_STOP)\b
       - match: \b(WIZARD_TRUE_DISPEL_MAGIC)\b
+      - match: \b(WIZARD_DISPEL_MAGIC)\b
       - match: \b(WIZARD_TRUE_SIGHT)\b
       - match: \b(WIZARD_VAMPIRIC_TOUCH)\b
       - match: \b(WIZARD_VOCALIZE)\b
@@ -4606,7 +4610,8 @@ repository:
     name: keyword.control.value.weidu-tp2
     patterns:
       - match: (\=\>|\+|-|\*|\/|=|\*|!|>|<|\?|:)
-      - match: \b(MODULO|REM|NOT|OR|AND|BAND|BOR|BXOR|BNOT|BLSL|BASR|EVAL)\b
+      - match: (&&?|\|(\|)?|^^|`)
+      - match: \b(MODULO|REM|NOT|OR|AND|BAND|BOR|BXOR|BNOT|BLSL|BLSR|BASR|EVAL)\b
 
   weidu-tp2-values:
     name: support.class.weidu-tp2.value
@@ -4622,6 +4627,7 @@ repository:
       - match: \b(STRING_EQUAL)\b
       - match: \b(STRING_EQUAL_CASE)\b
       - match: \b(STR_EQ)\b
+      - match: \b(STR_CMP)\b
       - match: \b(STRING_MATCHES_REGEXP)\b
       - match: \b(STRING_COMPARE_REGEXP)\b
       - match: \b(STRING_CONTAINS_REGEXP)\b
@@ -4661,6 +4667,7 @@ repository:
       - match: \b(VALID_SCRIPT_TRIGGERS)\b
       - match: \b(EVALUATE_BUFFER)\b
       - match: \b(WEIDU_ARCH)\b
+      - match: \b(WEIDU_EXECUTABLE)\b
       - match: \b(WEIDU_OS)\b
       - match: \b(WEIDU_VER)\b
       - match: \b(COMPONENT_NUMBER)\b
@@ -4786,7 +4793,7 @@ repository:
     patterns:
       - include: '#weidu-vars'
       - include: '#ielib-constants'
-      - match: (%)((\w*)(%[#!\-\w]+%)(\w*))(%)
+      - match: (%)((\w*)(%[#!<>=\-\w]+%)(\w*))(%)
         captures:
           '1':
             name: keyword.control.double-eval.weidu-tp2

--- a/syntaxes/weidu-tp2.tmLanguage.yml
+++ b/syntaxes/weidu-tp2.tmLanguage.yml
@@ -1072,7 +1072,6 @@ repository:
       - match: (%SCROLL_WIZARD_DIMENSION_DOOR%)
       - match: (%SCROLL_WIZARD_DIRE_CHARM%)
       - match: (%SCROLL_WIZARD_DISINTEGRATE%)
-      - match: (%SCROLL_WIZARD_DISPEL_MAGIC%)
       - match: (%SCROLL_WIZARD_DOMINATION%)
       - match: (%SCROLL_WIZARD_EMOTION_COURAGE%)
       - match: (%SCROLL_WIZARD_EMOTION_FEAR%)
@@ -1235,7 +1234,6 @@ repository:
       - match: (%SCROLL_WIZARD_TIME_STOP%)
       - match: (%SCROLL_WIZARD_TROLLISH_FORTITUDE%)
       - match: (%SCROLL_WIZARD_TRUE_DISPEL_MAGIC%)
-      - match: (%SCROLL_WIZARD_DISPEL_MAGIC%)
       - match: (%SCROLL_WIZARD_TRUE_SIGHT%)
       - match: (%SCROLL_WIZARD_VAMPIRIC_TOUCH%)
       - match: (%SCROLL_WIZARD_VITRIOLIC_SPHERE%)
@@ -1643,7 +1641,6 @@ repository:
       - match: (%WIZARD_TENSERS_TRANSFORMATION%)
       - match: (%WIZARD_TIME_STOP%)
       - match: (%WIZARD_TRUE_DISPEL_MAGIC%)
-      - match: (%WIZARD_DISPEL_MAGIC%)
       - match: (%WIZARD_TRUE_SIGHT%)
       - match: (%WIZARD_VAMPIRIC_TOUCH%)
       - match: (%WIZARD_VOCALIZE%)
@@ -2323,7 +2320,6 @@ repository:
       - match: \b(SCROLL_WIZARD_DIMENSION_DOOR)\b
       - match: \b(SCROLL_WIZARD_DIRE_CHARM)\b
       - match: \b(SCROLL_WIZARD_DISINTEGRATE)\b
-      - match: \b(SCROLL_WIZARD_DISPEL_MAGIC)\b
       - match: \b(SCROLL_WIZARD_DOMINATION)\b
       - match: \b(SCROLL_WIZARD_EMOTION_COURAGE)\b
       - match: \b(SCROLL_WIZARD_EMOTION_FEAR)\b
@@ -2486,7 +2482,6 @@ repository:
       - match: \b(SCROLL_WIZARD_TIME_STOP)\b
       - match: \b(SCROLL_WIZARD_TROLLISH_FORTITUDE)\b
       - match: \b(SCROLL_WIZARD_TRUE_DISPEL_MAGIC)\b
-      - match: \b(SCROLL_WIZARD_DISPEL_MAGIC)\b
       - match: \b(SCROLL_WIZARD_TRUE_SIGHT)\b
       - match: \b(SCROLL_WIZARD_VAMPIRIC_TOUCH)\b
       - match: \b(SCROLL_WIZARD_VITRIOLIC_SPHERE)\b
@@ -2894,7 +2889,6 @@ repository:
       - match: \b(WIZARD_TENSERS_TRANSFORMATION)\b
       - match: \b(WIZARD_TIME_STOP)\b
       - match: \b(WIZARD_TRUE_DISPEL_MAGIC)\b
-      - match: \b(WIZARD_DISPEL_MAGIC)\b
       - match: \b(WIZARD_TRUE_SIGHT)\b
       - match: \b(WIZARD_VAMPIRIC_TOUCH)\b
       - match: \b(WIZARD_VOCALIZE)\b

--- a/syntaxes/weidu-tp2.tmLanguage.yml
+++ b/syntaxes/weidu-tp2.tmLanguage.yml
@@ -4803,7 +4803,7 @@ repository:
             name: keyword.control.double-eval.weidu-tp2
           '6':
             name: keyword.control.double-eval.weidu-tp2
-      - match: (%[#!\-\w]+%)
+      - match: (%[#!<>=\-\w]+%)
 
   vars:
     patterns:

--- a/syntaxes/weidu-tp2.tmLanguage.yml
+++ b/syntaxes/weidu-tp2.tmLanguage.yml
@@ -4793,7 +4793,7 @@ repository:
     patterns:
       - include: '#weidu-vars'
       - include: '#ielib-constants'
-      - match: (%)((\w*)(%[#!<>=\-\w]+%)(\w*))(%)
+      - match: (%)((\w*)(%[#!\-\w]+%)(\w*))(%)
         captures:
           '1':
             name: keyword.control.double-eval.weidu-tp2
@@ -4803,7 +4803,7 @@ repository:
             name: keyword.control.double-eval.weidu-tp2
           '6':
             name: keyword.control.double-eval.weidu-tp2
-      - match: (%[#!<>=\-\w]+%)
+      - match: (%[#!\-\w]+%)
 
   vars:
     patterns:


### PR DESCRIPTION
- ~~Add characters `>`, `<` and `=` to `#non-weidu-vars`~~ (removed).
- Add missing `WIZARD_DISPEL_MAGIC` to Syntax Highlighting.
- Add missing `WEIDU_EXECUTABLE`.
- Add missing `ADD_PROJECTILE` feature.
- Add missing `STR_CMP` to Syntax Highlighting.
- Add missing operators to `weidu-tp2-value-operators`.